### PR TITLE
Fix wrong index after removeSlide

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2000,7 +2000,9 @@
         if (_.slideCount < 1 || index < 0 || index > _.slideCount - 1) {
             return false;
         }
-
+        
+        _.currentSlide = _.currentSlide-1;
+         
         _.unload();
 
         if (removeAll === true) {


### PR DESCRIPTION
After remove some slides, nav arrow will stop wroking due to wrong index in Slick.prototype.removeSlide